### PR TITLE
Padronização dos Controllers

### DIFF
--- a/infra/controller.js
+++ b/infra/controller.js
@@ -1,0 +1,26 @@
+import { InternalServerError, MethodNotAllowedError } from "infra/errors.js";
+
+function onNoMatchHandler(request, response) {
+  const publicErrorObject = new MethodNotAllowedError();
+  response.status(publicErrorObject.statusCode).json(publicErrorObject);
+}
+
+function onErrorHandler(error, request, response) {
+  const publicErrorObject = new InternalServerError({
+    statusCode: error.statusCode,
+    cause: error,
+  });
+
+  console.error(publicErrorObject);
+
+  response.status(publicErrorObject.statusCode).json(publicErrorObject);
+}
+
+const controller = {
+  errorHandlers: {
+    onNoMatch: onNoMatchHandler,
+    onError: onErrorHandler,
+  },
+};
+
+export default controller;

--- a/infra/database.js
+++ b/infra/database.js
@@ -1,4 +1,5 @@
 import { Client } from "pg";
+import { ServiceError } from "./errors";
 
 async function query(queryObject) {
   let client;
@@ -8,10 +9,12 @@ async function query(queryObject) {
     client = await getNewClient();
     result = await client.query(queryObject);
     return result;
-  } catch (err) {
-    console.log("\n erro dentro do catch do database.js");
-    console.error(err);
-    throw err;
+  } catch (error) {
+    const serviceErrorObject = new ServiceError({
+      message: "Erro na conexão com o Banco ou na Query.",
+      cause: error,
+    });
+    throw serviceErrorObject;
   } finally {
     await client?.end();
   }

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -1,12 +1,52 @@
 export class InternalServerError extends Error {
-  constructor({ cause }) {
+  constructor({ cause, statusCode }) {
     super("Um error interno não esperado aconteceu", {
       cause,
     });
 
     this.name = "InternalServerError";
     this.action = "Entre em contato com o suporte";
-    this.statusCode = 500;
+    this.statusCode = statusCode || 500;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}
+
+export class ServiceError extends Error {
+  constructor({ cause, message }) {
+    super(message || "Serviço Indisponivel no momento.", {
+      cause,
+    });
+
+    this.name = "ServiceError";
+    this.action = "Verifique se o serviço está disponível";
+    this.statusCode = 503;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}
+
+export class MethodNotAllowedError extends Error {
+  constructor() {
+    super("Método não permitido para este endpoint");
+    this.name = "MethodNotAllowed";
+    this.message = "Método não permitido para este endpoint";
+    this.action = "Verifique se o método enviado é válido para este endpoint";
+    this.statusCode = 405;
   }
 
   toJSON() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "dotenv": "16.4.7",
         "dotenv-expand": "12.0.1",
         "next": "15.1.7",
+        "next-connect": "^1.0.0",
         "node-pg-migrate": "7.9.1",
         "pg": "8.13.3",
         "react": "19.0.0",
@@ -2470,6 +2471,12 @@
       "dependencies": {
         "tslib": "^2.8.0"
       }
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -8974,6 +8981,19 @@
         }
       }
     },
+    "node_modules/next-connect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-connect/-/next-connect-1.0.0.tgz",
+      "integrity": "sha512-FeLURm9MdvzY1SDUGE74tk66mukSqL6MAzxajW7Gqh6DZKBZLrXmXnGWtHJZXkfvoi+V/DUe9Hhtfkl4+nTlYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsconfig/node16": "^1.0.3",
+        "regexparam": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -10104,6 +10124,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexparam": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-2.0.2.tgz",
+      "integrity": "sha512-A1PeDEYMrkLrfyOwv2jwihXbo9qxdGD3atBYQA9JJgreAx8/7rC6IUkWOw2NQlOxLp2wL0ifQbh1HuidDfYA6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "dotenv": "16.4.7",
     "dotenv-expand": "12.0.1",
     "next": "15.1.7",
+    "next-connect": "^1.0.0",
     "node-pg-migrate": "7.9.1",
     "pg": "8.13.3",
     "react": "19.0.0",

--- a/pages/api/v1/migrations/index.js
+++ b/pages/api/v1/migrations/index.js
@@ -1,56 +1,52 @@
+import { createRouter } from "next-connect";
 import migrationRunner from "node-pg-migrate";
 import { resolve } from "node:path";
 import database from "infra/database.js";
+import controller from "infra/controller.js";
 
-async function migrations(request, response) {
-  const allowedMethods = ["GET", "POST"];
-  let dbClient;
+const router = createRouter();
 
-  if (!allowedMethods.includes(request.method)) {
-    return response
-      .status(405)
-      .json([
-        {
-          message: `Method ${request.method} not allowed.`,
-        },
-      ])
-      .end();
-  }
+router.get(getHandler);
+router.post(postHandler);
 
-  try {
-    dbClient = await database.getNewClient();
+export default router.handler(controller.errorHandlers);
 
-    let defaultMigrations = {
-      dbClient: dbClient,
-      dir: resolve("infra", "migrations"),
-      direction: "up",
-      verbose: true,
-      migrationsTable: "pgmigrations",
-    };
+async function getDefaultMigrationsOptions() {
+  const dbClient = await database.getNewClient();
 
-    if (request.method === "GET") {
-      const pendingMigrations = await migrationRunner({
-        ...defaultMigrations,
-        dryRun: true,
-      });
-      return response.status(200).json(pendingMigrations);
-    }
-
-    if (request.method === "POST") {
-      const migratedMigrations = await migrationRunner(defaultMigrations);
-
-      if (migratedMigrations.length > 0) {
-        return response.status(201).json(migratedMigrations);
-      }
-
-      return response.status(200).json(migratedMigrations);
-    }
-  } catch (error) {
-    console.log(error);
-    throw error;
-  } finally {
-    await dbClient.end();
-  }
+  return {
+    dbClient: dbClient,
+    dir: resolve("infra", "migrations"),
+    direction: "up",
+    verbose: true,
+    migrationsTable: "pgmigrations",
+  };
 }
 
-export default migrations;
+async function getHandler(request, response) {
+  const defaultMigrations = await getDefaultMigrationsOptions();
+  return migrationRunner({
+    ...defaultMigrations,
+    dryRun: true,
+  })
+    .then((pendingMigrations) => {
+      return response.status(200).json(pendingMigrations);
+    })
+    .finally(() => {
+      defaultMigrations?.dbClient.end();
+    });
+}
+
+async function postHandler(request, response) {
+  const defaultMigrations = await getDefaultMigrationsOptions();
+  return migrationRunner(defaultMigrations)
+    .then((migratedMigrations) => {
+      if (migratedMigrations?.length > 0) {
+        return response.status(201).json(migratedMigrations);
+      }
+      return response.status(200).json(migratedMigrations);
+    })
+    .finally(() => {
+      defaultMigrations?.dbClient.end();
+    });
+}

--- a/pages/api/v1/status/index.js
+++ b/pages/api/v1/status/index.js
@@ -1,45 +1,38 @@
+import { createRouter } from "next-connect";
 import database from "infra/database.js";
-import { InternalServerError } from "infra/errors.js";
+import controller from "infra/controller.js";
 
-async function status(request, response) {
-  try {
-    const databaseStatusUpdatedAt = new Date().toISOString();
-    const databaseVersion = await database.query("SHOW server_version;");
-    const databaseMaxConnections = await database.query(
-      "SHOW max_connections;",
-    );
-    const dataActiveConnections = await database.query({
-      text: `SELECT count(*)::int AS active_connections FROM pg_stat_activity WHERE datname = $1;`,
-      values: [process.env.POSTGRES_DB],
-    });
+const router = createRouter();
 
-    const databaseInfo = {
-      postgres_version: databaseVersion.rows[0].server_version,
-      max_connections: parseInt(databaseMaxConnections.rows[0].max_connections),
-      active_connections: parseInt(
-        dataActiveConnections.rows[0].active_connections,
-      ),
-    };
+router.get(getHandler);
 
-    response.status(200).json({
-      database_status_updated_at: databaseStatusUpdatedAt,
-      dependencies: {
-        database: {
-          version: databaseInfo.postgres_version,
-          max_connections: parseInt(databaseInfo.max_connections),
-          opened_connections: databaseInfo.active_connections,
-        },
+export default router.handler(controller.errorHandlers);
+
+async function getHandler(request, response) {
+  const databaseStatusUpdatedAt = new Date().toISOString();
+  const databaseVersion = await database.query("SHOW server_version;");
+  const databaseMaxConnections = await database.query("SHOW max_connections;");
+  const dataActiveConnections = await database.query({
+    text: `SELECT count(*)::int AS active_connections FROM pg_stat_activity WHERE datname = $1;`,
+    values: [process.env.POSTGRES_DB],
+  });
+
+  const databaseInfo = {
+    postgres_version: databaseVersion.rows[0].server_version,
+    max_connections: parseInt(databaseMaxConnections.rows[0].max_connections),
+    active_connections: parseInt(
+      dataActiveConnections.rows[0].active_connections,
+    ),
+  };
+
+  response.status(200).json({
+    database_status_updated_at: databaseStatusUpdatedAt,
+    dependencies: {
+      database: {
+        version: databaseInfo.postgres_version,
+        max_connections: parseInt(databaseInfo.max_connections),
+        opened_connections: databaseInfo.active_connections,
       },
-    });
-  } catch (error) {
-    const publicErrorObject = new InternalServerError({
-      cause: error,
-    });
-
-    console.log("\n erro dentro do catch do controller");
-    console.error(publicErrorObject);
-    response.status(500).json(publicErrorObject);
-  }
+    },
+  });
 }
-
-export default status;

--- a/tests/integration/api/v1/status/post.test.js
+++ b/tests/integration/api/v1/status/post.test.js
@@ -1,0 +1,25 @@
+import orchestrator from "tests/orchestrator.js";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+});
+
+describe("POST para /api/v1/status", () => {
+  describe("Usuário Anônimo", () => {
+    test("Retornando Método não permitido", async () => {
+      const response = await fetch("http://localhost:3000/api/v1/status", {
+        method: "POST",
+      });
+      expect(response.status).toBe(405);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "MethodNotAllowed",
+        message: "Método não permitido para este endpoint",
+        action: "Verifique se o método enviado é válido para este endpoint",
+        status_code: 405,
+      });
+    });
+  });
+});


### PR DESCRIPTION
1. Padroniza os Controllers dos enpoitns `/migrations` e `/status`
2. Adiciona 2 novos erros customizados: `MethodNotAllowedError` e `ServiceError`
3. Faz o `InternalServerError` aceitar injeção do `statusCode`